### PR TITLE
Fix page title

### DIFF
--- a/themes/clearvision_sapphire.html
+++ b/themes/clearvision_sapphire.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="https://www.w3.org/1999/xhtml" xmlns:fb="http://ogp.me/ns/fb#">
-<title>ClearVision - Ruby</title>
+<title>ClearVision - Sapphire</title>
 <meta charset=utf-8>
 <meta content="IE=edge" http-equiv=X-UA-Compatible>
 <meta content="width=device-width,initial-scale=1" name=viewport>
@@ -14,7 +14,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://betterdocs.net/" />
 <meta property="og:site_name" content="BetterDiscord Docs" />
-<meta property="og:title" content="ClearVision - Ruby" />
+<meta property="og:title" content="ClearVision - Sapphire" />
 <meta property="og:image" content="https://i.imgur.com/3sc5OG3.png" />
 <!-- Icon -->
 <link href=https://imgur.com/GZVRLfz.png rel="shortcut icon">


### PR DESCRIPTION
Mistakenly read "Ruby" instead of "Sapphire"
