### PR TITLE
Fix broken plugin link

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -761,7 +761,7 @@ Now draggable</p>
                             </li>
                             
                             <li class="plugin on">
-                                <a href="http://viid.me/qtS4IA" class="plugin-name" target="_blank">Static Avatars</a>
+                                <a href="https://github.com/noodlebox/betterdiscord-plugins/blob/master/StaticAvatars.plugin.js" class="plugin-name" target="_blank">Static Avatars</a>
                                 <p class="plugin-desc">Don't animate avatars in the chat area</p>
                                 <div class="plugin-tag-list">
 


### PR DESCRIPTION
That branch was deleted, so I switched the link to master.

In my repo, branches other than master are usually for work in progress and eventually get cleaned up after I merge them. Just link to things from the master branch to avoid broken links in the future.

Also, I was wondering, why the switch to interstitial ad links? Borderline malicious ads are getting in the way of this being an otherwise useful resource for a decent number of people. And I'm sure you can see in the BD server that it's also not really encouraging collaboration :P (though I haven't kept up with whatever other drama there's been between you and them). To me, it just seems kind of tacky.

Are the ads actually earning enough to be worth the annoyance?