### PR TITLE
Update 4chan quoter

### DIFF
--- a/assets/4Chan_Quoting.plugin.js
+++ b/assets/4Chan_Quoting.plugin.js
@@ -1,52 +1,41 @@
-//META{"name":"4Chan_Quoting"}*//
+//META{"name":"FourChanQuoting"}*//
 
-function meh() {}
+function FourChanQuoting() {}
 
-meh.processChat = function() {
+FourChanQuoting.processChat = function() {
 	setTimeout(function() {
 		$(".comment .body .markup:not(.meh-scanned), .comment .markup>span:not(.meh-scanned)").each(function() {
-			var tagRegex = new RegExp(`(?!\.)&gt;(.+)`, 'igm');
+			var tagRegex = new RegExp(`&gt;(.+)`, 'igm');
 			var html = $(this).html();
 			$(this).html(html.replace(tagRegex, `<b style='color: #789922;'>&gt;$1</b>`));
 		}).addClass("meh-scanned");
 	},250);
 };
 
-meh.prototype.load = function() {
-};
+FourChanQuoting.prototype.load = function() {};
 
-meh.prototype.unload = function() {
-};
+FourChanQuoting.prototype.unload = function() {};
 
-meh.prototype.start = function() {
-	meh.processChat();
-};
-	
-meh.prototype.onMessage = function () {
-	meh.processChat();
-};
-meh.prototype.onSwitch = function () {
-	meh.processChat();
-};
+FourChanQuoting.prototype.start = FourChanQuoting.processChat;
 
-meh.prototype.stop = function () {
-};
+FourChanQuoting.prototype.stop = function () {};
 
-meh.prototype.getName = function () {
+FourChanQuoting.prototype.onMessage = FourChanQuoting.processChat;
+
+FourChanQuoting.prototype.onSwitch = FourChanQuoting.processChat;
+
+FourChanQuoting.prototype.getName = function () {
     return "4Chan_Quoting";
 };
 
-meh.prototype.getDescription = function () {
+FourChanQuoting.prototype.getDescription = function () {
     return "Send a message with > at the start to make the text green like 4Chan!";
 };
 
-meh.prototype.getVersion = function () {
+FourChanQuoting.prototype.getVersion = function () {
     return "1.0";
 };
 
-meh.prototype.getAuthor = function () {
+FourChanQuoting.prototype.getAuthor = function () {
     return "MRVDOG";
-};
-
-meh.prototype.getSettingsPanel = function () {
 };

--- a/plugins.html
+++ b/plugins.html
@@ -775,7 +775,7 @@ Now draggable</p>
                             </li>
                             
                             <li class="plugin on">
-                                <a href="http://viid.me/qtBLyP" class="plugin-name" target="_blank">4Chan Quoting</a>
+                                <a href="https://github.com/0mniscient/BetterDiscord/blob/gh-pages/assets/4Chan_Quoting.plugin.js" class="plugin-name" target="_blank">4Chan Quoting</a>
                                 <p class="plugin-desc">Send a message with > at the start of a message to make the text green like 4Chan!</p>
                                 <div class="plugin-tag-list">
 


### PR DESCRIPTION
The 4chan quoter plugin you added has been unmaintained for a while. This fixes it to at least work without breaking everything, though it's still clunky and has a few other issues that aren't likely to be fixed.