### PR TITLE
Mistyped text on method descriptions.

### DIFF
--- a/plugin_api.html
+++ b/plugin_api.html
@@ -115,11 +115,11 @@
                                                         </tr>
                                                         <tr>
                                                             <td>BdApi.getUserIdByName("name");</td>
-                                                            <td>Attempts to return username by userid</td>
+                                                            <td>Attempts to return userid by username</td>
                                                         </tr>
                                                         <tr>
                                                             <td>BdApi.getUserNameById("id");</td>
-                                                            <td>Attempts to return userid by username</td>
+															<td>Attempts to return username by userid</td>
                                                         </tr>
                                                         <tr>
                                                             <td>BdApi.setPlaying("game");</td>


### PR DESCRIPTION
BdApi.getUserIdByName("name") and BdApi.getUserNameById("id") descriptions where switched.