### PR TITLE
Remove obsolete HD Avatars plugin

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -160,7 +160,7 @@
                 <h1 id="plugin-list-title" class="bd-header">
                       <div id="betterdiscord"> <span class="bd-title">Better</span>Discord <a class="article-anchor page" href="#betterdiscord" aria-hidden="true"></a></div>
                     </h1>
-                <div id="plugin-list-count">86 Plugins</div>
+                <div id="plugin-list-count">85 Plugins</div>
                 <hr>
               </header>
                  
@@ -432,10 +432,6 @@
                 <li class="plugin on"> <a href="https://github.com/Arashiryuu/crap/blob/master/orangeTexting.plugin.js" class="plugin-name" target="_blank">OrangeText</a>
                       <p class="plugin-desc">Use a less-than symbol &#60; at the end of a sentence to make text orange.</p>
                       <div class="plugin-tag-list"> <a href="#Arashiryuu" class="plugin-tag">Arashiryuu</a> <a href="#Orange" class="plugin-tag">Orange</a> <a href="#Quote" class="plugin-tag">Quote</a> </div>
-                    </li>
-                <li class="plugin on"> <a href="https://github.com/noodlebox/betterdiscord-plugins/blob/master/HDAvatars.plugin.js" class="plugin-name" target="_blank">HD Avatars</a>
-                      <p class="plugin-desc">Use higher-quality versions of avatar images when available</p>
-                      <div class="plugin-tag-list"> <a href="#Noodlebox" class="plugin-tag">Noodlebox</a> <a href="#HD" class="plugin-tag">HD</a> <a href="#Avatar" class="plugin-tag">Avatar</a> <a href="#Quality" class="plugin-tag tag-invis">Quality</a> <a href="#High" class="plugin-tag tag-invis">High</a> </div>
                     </li>
                 <li class="plugin on"> <a href="https://github.com/yoshivb/bdCustomNotifications/blob/master/CustomNotifications.plugin.js" class="plugin-name" target="_blank">CustomNotifications</a>
                       <p class="plugin-desc">Allows you to change the sounds for the notifications.</p>


### PR DESCRIPTION
This one has been obsolete for a while, ever since Discord increased the default size of avatar images. More recent updates have finally broken it though (noodlebox/betterdiscord-plugins#20), and fixing it isn't a big priority for me right now.